### PR TITLE
[Graph Algo] Preparation Works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2021" # Allowed values are 2015, 2018, 2021
 
 [dependencies]
 cargo-husky = "1"
+ordered-float = "3.0.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["user-hooks"]
+
 
 [lib]
 name = "lib_router"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@ mod types {
     pub mod status;
 }
 
+mod utils {
+    pub mod haversine;
+}
+
 /// Adds one to a number.
 ///
 /// # Arguments

--- a/src/types/location.rs
+++ b/src/types/location.rs
@@ -3,6 +3,8 @@
 //! There may be special types of `Location` such as a moving
 //! coordinate.
 
+use ordered_float::OrderedFloat;
+
 /// A [`Location`] is an interface type that represents a geographic
 /// location of an object. Typically, this type is used in tandem with
 /// the [`Node`](`super::node::Node`) type.
@@ -12,9 +14,9 @@
 ///
 /// Float values are used to achieve a 5-decimal precision (0.00001),
 /// which narrows the error margin to a meter.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash, Eq)]
 pub struct Location {
-    pub longitude: f32,
-    pub latitude: f32,
-    pub altitude_meters: f32,
+    pub longitude: OrderedFloat<f32>,
+    pub latitude: OrderedFloat<f32>,
+    pub altitude_meters: OrderedFloat<f32>,
 }

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -13,6 +13,7 @@
 //!
 //! This pattern allows functions to be agnostic of the type of `Node` to
 //! accept as argument.
+use ordered_float::OrderedFloat;
 
 use super::location;
 use super::status;
@@ -33,7 +34,7 @@ pub trait AsNode {
 ///
 /// Since the actual vertex can be any object, a generic struct is
 /// needed for the purpose of abstraction and clarity.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash, Eq)]
 pub struct Node {
     /// Typed as a [`String`] to allow for synthetic ids. One purpose of
     /// using a synthetic id is to allow for partitioned indexing on the
@@ -68,7 +69,7 @@ pub struct Vertipad<'a> {
     pub node: Node,
 
     /// FAA regulated pad size.
-    pub size_square_meters: f32,
+    pub size_square_meters: OrderedFloat<f32>,
 
     /// Certain pads may have special purposes. For example, a pad may
     /// be used for medical emergency services.
@@ -86,7 +87,7 @@ impl Vertipad<'_> {
     /// CAUTION: Testing purposes only. Updates should not be done from
     /// the router lib.
     #[allow(dead_code)]
-    fn update_size_square_meters(&mut self, new_size: f32) {
+    fn update_size_square_meters(&mut self, new_size: OrderedFloat<f32>) {
         self.size_square_meters = new_size;
     }
 }
@@ -143,14 +144,14 @@ mod node_type_tests {
             node: Node {
                 uid: "vertipad_1".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: OrderedFloat(0.0),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
             },
-            size_square_meters: 100.0,
+            size_square_meters: OrderedFloat(100.0),
             permissions: vec!["medical".to_string()],
             owner_port: None,
         };
@@ -158,14 +159,14 @@ mod node_type_tests {
             node: Node {
                 uid: "vertipad_2".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: OrderedFloat(0.0),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
             },
-            size_square_meters: 100.0,
+            size_square_meters: OrderedFloat(100.0),
             permissions: vec!["medical".to_string()],
             owner_port: None,
         };
@@ -173,14 +174,14 @@ mod node_type_tests {
             node: Node {
                 uid: "vertipad_3".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: OrderedFloat(0.0),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
             },
-            size_square_meters: 100.0,
+            size_square_meters: OrderedFloat(100.0),
             permissions: vec!["medical".to_string()],
             owner_port: None,
         };
@@ -188,9 +189,9 @@ mod node_type_tests {
             node: Node {
                 uid: "vertiport_1".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: 0.0.into(),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
@@ -202,14 +203,14 @@ mod node_type_tests {
             node: Node {
                 uid: "vertipad_4".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: 0.0.into(),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
             },
-            size_square_meters: 100.0,
+            size_square_meters: OrderedFloat(100.0),
             permissions: vec!["medical".to_string()],
             owner_port: None,
         };
@@ -230,7 +231,7 @@ mod node_type_tests {
 
         let new_pad_size = 200.0;
         // update the size of vertipad_1.
-        vertipad_1.update_size_square_meters(new_pad_size.clone());
+        vertipad_1.update_size_square_meters(new_pad_size.into());
 
         // check that the size of vertipad_1 has been updated.
         assert_eq!(vertipad_1.size_square_meters, new_pad_size);
@@ -242,14 +243,14 @@ mod node_type_tests {
             node: Node {
                 uid: "vertipad_1".to_string(),
                 location: location::Location {
-                    longitude: -73.935242,
-                    latitude: 40.730610,
-                    altitude_meters: 0.0,
+                    longitude: OrderedFloat(-73.935242),
+                    latitude: OrderedFloat(40.730610),
+                    altitude_meters: OrderedFloat(0.0),
                 },
                 forward_to: None,
                 status: status::Status::Ok,
             },
-            size_square_meters: 100.0,
+            size_square_meters: OrderedFloat(100.0),
             permissions: vec!["public".to_string()],
             owner_port: None,
         };

--- a/src/types/status.rs
+++ b/src/types/status.rs
@@ -1,7 +1,7 @@
 //! Definition for the [`Status`] type, implemented by an enum.
 
 /// Represents the operating status of a [`super::node::Node`].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Hash, Eq)]
 #[allow(dead_code)]
 pub enum Status {
     Ok,

--- a/src/utils/haversine.rs
+++ b/src/utils/haversine.rs
@@ -1,0 +1,61 @@
+//! Implementation of the Haversine formula for calculating the distance
+//! between two points on a sphere.
+//!
+//! See [Wikipedia](https://en.wikipedia.org/wiki/Haversine_formula) for
+//! more.
+//!
+//! **Distance is returned in kilometers**.
+
+use crate::types::location::Location;
+
+/// Calculates the distance between two points on a sphere.
+///
+/// # Arguments
+/// * `from` - The starting point.
+/// * `to` - The ending point.
+///
+/// # Returns
+/// The distance between the two points in kilometers.
+///
+/// # Notes
+/// The current formula does ***not*** take into account the altitude of the
+/// points.
+///
+/// Float 32 values are used to achieve a 5-decimal precision (0.00001),
+/// which narrows the error margin to a meter.
+pub fn distance(start: &Location, end: &Location) -> f32 {
+    // km in radians
+    let kilometers: f32 = 6371.0;
+
+    let d_lat: f32 = (end.latitude.into_inner() - start.latitude.into_inner()).to_radians();
+    let d_lon: f32 = (end.longitude.into_inner() - start.longitude.into_inner()).to_radians();
+    let lat1: f32 = (start.latitude.into_inner()).to_radians();
+    let lat2: f32 = (end.latitude.into_inner()).to_radians();
+
+    let a: f32 = ((d_lat / 2.0).sin()) * ((d_lat / 2.0).sin())
+        + ((d_lon / 2.0).sin()) * ((d_lon / 2.0).sin()) * (lat1.cos()) * (lat2.cos());
+    let c: f32 = 2.0 * ((a.sqrt()).atan2((1.0 - a).sqrt()));
+
+    kilometers * c
+}
+
+#[cfg(test)]
+pub mod haversine_test {
+    use super::*;
+    use ordered_float::OrderedFloat;
+
+    #[test]
+    fn haversine_distance_in_kilometers() {
+        let start = Location {
+            latitude: OrderedFloat(38.898556),
+            longitude: OrderedFloat(-77.037852),
+            altitude_meters: OrderedFloat(0.0),
+        };
+        let end = Location {
+            latitude: OrderedFloat(38.897147),
+            longitude: OrderedFloat(-77.043934),
+            altitude_meters: OrderedFloat(0.0),
+        };
+        assert_eq!(0.5496312, distance(&start, &end));
+    }
+}


### PR DESCRIPTION
Enhancements:
* Make current `Node` objects hashable and equitable
* Implement the haversine formula for computing distances between two geo points on a sphere. To test this, use the [online calculator](https://www.vcalc.com/wiki/vCalc/Haversine+-+Distance). Note that this online tool does not give 5 decimal precisions, but the whole number part should be roughly in the ballpark.

This haversine function is essentially a very simplified cost function for computing the weight of edges on a graph.