### PR TITLE
chore: update storage dependency to main branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ quaternion              = "0.4"
 rand                    = "0.8"
 rrule                   = "0.10"
 serde                   = { version = "1.0", features = ["derive"] }
-svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage.git", branch = "develop" }
+svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage.git", branch = "main" }
 vecmath                 = "1.0"
 
 [dependencies.uuid]


### PR DESCRIPTION
scheduler and router need to point to the same version (branch) of the storage service