### PR TITLE
feat: update svc-storage version, expose deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,21 +7,20 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-husky             = "1"
-chrono                  = "0.4"
-chrono-tz               = "0.6"
-iso8601-duration        = "0.1"
-log                     = "0.4"
-once_cell               = "1.15"
-ordered-float           = { version = "3.0", features = ["serde"] }
-petgraph                = "0.6"
-prost-types             = "0.11"
-quaternion              = "0.4"
-rand                    = "0.8"
-rrule                   = "0.10"
-serde                   = { version = "1.0", features = ["derive"] }
-svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage.git", branch = "develop" }
-vecmath                 = "1.0"
+cargo-husky      = "1"
+chrono           = "0.4"
+chrono-tz        = "0.6"
+iso8601-duration = "0.1"
+log              = "0.4"
+once_cell        = "1.15"
+ordered-float    = { version = "3.0", features = ["serde"] }
+petgraph         = "0.6"
+prost-types      = "0.11"
+quaternion       = "0.4"
+rand             = "0.8"
+rrule            = "0.10"
+serde            = { version = "1.0", features = ["derive"] }
+vecmath          = "1.0"
 
 [dependencies.uuid]
 features = [
@@ -36,6 +35,9 @@ default-features = false          # Disable features which are enabled by defaul
 features         = ["user-hooks"]
 version          = "1"
 
+[dependencies.svc-storage-client-grpc]
+git = "https://github.com/Arrow-air/svc-storage.git"
+tag = "v0.9.0-develop.14"
 
 [lib]
 name = "router"

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -58,7 +58,7 @@ pub struct Node {
 
     /// Denote the geographical position of the node.
     ///
-    /// See also [`Location`].
+    /// See also [`location::Location`].
     pub location: location::Location,
 
     /// A node might be unavailable for some reasons. If `forward_to` is
@@ -68,7 +68,7 @@ pub struct Node {
 
     /// Indicate the operation status of a node.
     ///
-    /// See also [`Status`](Status::Status).
+    /// See also [`status::Status`].
     pub status: status::Status,
 }
 

--- a/src/utils/router_state.rs
+++ b/src/utils/router_state.rs
@@ -12,9 +12,13 @@ use ordered_float::OrderedFloat;
 use prost_types::Timestamp;
 use rrule::Tz;
 use std::str::FromStr;
-use svc_storage_client_grpc::flight_plan::{Data as FlightPlanData, Object as FlightPlan};
-use svc_storage_client_grpc::vehicle::Object as Vehicle;
-use svc_storage_client_grpc::vertiport::Object as Vertiport;
+
+// Expose so svc-scheduler doesn't assume same svc-storage version
+pub use svc_storage_client_grpc::resources::flight_plan::{
+    Data as FlightPlanData, Object as FlightPlan,
+};
+pub use svc_storage_client_grpc::resources::vehicle::Object as Vehicle;
+pub use svc_storage_client_grpc::resources::vertiport::Object as Vertiport;
 
 /// Query struct for generating nodes near a location.
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Needed for some other module development

svc-scheduler should transfer needed information from `svc-storage-client-grpc::resources::FlightPlanData` to `lib-router::FlightPlanData`

Shouldn't assume that they have the same svc-storage dep version