### PR TITLE
fix: handle schedule unwrap

### DIFF
--- a/src/utils/schedule.rs
+++ b/src/utils/schedule.rs
@@ -91,14 +91,12 @@ impl FromStr for Calendar {
             let duration = header_parts[1];
             let str = "DTSTART:".to_owned() + dtstart + "\n" + rrules.join("\n").as_str();
             let rrset_res = RRuleSet::from_str(&str);
-            if rrset_res.is_err() {
-                error!(
-                    "Invalid rrule set: {}",
-                    rrset_res.err().unwrap().to_string()
-                );
+
+            let Ok(rrule_set) = rrset_res else {
+                error!("Invalid rrule set: {:?}", rrset_res.unwrap_err());
                 return Err(());
-            }
-            let rrule_set = rrset_res.unwrap();
+            };
+
             recurrent_events.push(RecurrentEvent {
                 rrule_set,
                 duration: duration.to_string(),


### PR DESCRIPTION
Allows us to run the tests without providing schedules for each sample vertiport.

NOTE: This module will be merged back into svc-scheduler in R3, where some of the functionality may be removed in favor of Redis graphs. Not focusing on the UTs this release.